### PR TITLE
Fix for Visual C++ 2015

### DIFF
--- a/src/Makefile.w32
+++ b/src/Makefile.w32
@@ -24,10 +24,11 @@ GIFWRITE_OBJ = gifwrite.obj
 # probably need to change it if you're using a different compiler. You can
 # define it to the empty string, in which case Gifsicle will compile fine,
 # but you won't be able to use wildcards in file name arguments.
-SETARGV_OBJ = $(MSDevDir)\lib\setargv.obj
+SETARGV_OBJ = # $(MSDevDir)\lib\setargv.obj
 
 CC = cl
-CFLAGS = -I.. -I..\include -DHAVE_CONFIG_H -D_CONSOLE /W3 /O2
+CFLAGS = -I.. -I..\include -DHAVE_CONFIG_H -D_CONSOLE \
+	-D_CRT_SECURE_NO_WARNINGS /W3 /O2
 
 GIFSICLE_OBJS = clp.obj fmalloc.obj giffunc.obj gifread.obj gifunopt.obj \
 	$(GIFWRITE_OBJ) merge.obj optimize.obj quantize.obj support.obj \

--- a/src/Makefile.w32
+++ b/src/Makefile.w32
@@ -18,33 +18,24 @@
 GIFWRITE_OBJ = gifwrite.obj
 #GIFWRITE_OBJ = ungifwrt.obj
 
-# *** SUPPORTING WILDCARD EXPANSION ***
-# Define `SETARGV_OBJ' to the filename for the `setargv.obj' object file.
-# The definition included here works for Microsoft compilers; you will
-# probably need to change it if you're using a different compiler. You can
-# define it to the empty string, in which case Gifsicle will compile fine,
-# but you won't be able to use wildcards in file name arguments.
-SETARGV_OBJ = # $(MSDevDir)\lib\setargv.obj
-
 CC = cl
-CFLAGS = -I.. -I..\include -DHAVE_CONFIG_H -D_CONSOLE \
-	-D_CRT_SECURE_NO_WARNINGS /W3 /O2
+CFLAGS = -I.. -I..\include -DHAVE_CONFIG_H -D_CONSOLE /W2 /O2
+LDLIBS = setargv.obj
 
 GIFSICLE_OBJS = clp.obj fmalloc.obj giffunc.obj gifread.obj gifunopt.obj \
 	$(GIFWRITE_OBJ) merge.obj optimize.obj quantize.obj support.obj \
-	xform.obj gifsicle.obj $(SETARGV_OBJ)
+	xform.obj gifsicle.obj
 
-GIFDIFF_OBJS = clp.obj fmalloc.obj giffunc.obj gifread.obj gifdiff.obj \
-	$(SETARGV_OBJ)
+GIFDIFF_OBJS = clp.obj fmalloc.obj giffunc.obj gifread.obj gifdiff.obj
 
 .c.obj:
 	$(CC) $(CFLAGS) /c $<
 
 gifsicle.exe: $(GIFSICLE_OBJS)
-	$(CC) $(CFLAGS) /Fegifsicle.exe $(GIFSICLE_OBJS)
+	$(CC) $(CFLAGS) /Fegifsicle.exe $(GIFSICLE_OBJS) /link $(LDLIBS)
 
 gifdiff.exe: $(GIFDIFF_OBJS)
-	$(CC) $(CFLAGS) /Fegifdiff.exe $(GIFDIFF_OBJS)
+	$(CC) $(CFLAGS) /Fegifdiff.exe $(GIFDIFF_OBJS) /link $(LDLIBS)
 
 clp.obj: ..\config.h ..\include\lcdf\clp.h clp.c
 

--- a/src/win32cfg.h
+++ b/src/win32cfg.h
@@ -11,7 +11,9 @@
 /* #undef GIF_UNGIF */
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-/* #undef HAVE_INTTYPES_H */
+#if _MSC_VER >= 1900
+# define HAVE_INTTYPES_H 1
+#endif
 
 /* Define to 1 if you have the <memory.h> header file. */
 /* #undef HAVE_MEMORY_H */
@@ -23,7 +25,9 @@
 #define HAVE_POW 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
-/* #undef HAVE_STDINT_H */
+#if _MSC_VER >= 1900
+# define HAVE_STDINT_H 1
+#endif
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -50,7 +54,9 @@
 /* #undef HAVE_SYS_TYPES_H */
 
 /* Define to 1 if the system has the type `uintptr_t'. */
-/* #undef HAVE_UINTPTR_T */
+#if _MSC_VER >= 1900
+# define HAVE_UINTPTR_T 1
+#endif
 
 /* Define to 1 if you have the <unistd.h> header file. */
 /* #undef HAVE_UNISTD_H */
@@ -92,11 +98,7 @@
 #define SIZEOF_UNSIGNED_INT 4
 
 /* The size of `unsigned long', as computed by sizeof. */
-#ifdef _WIN64
-#define SIZEOF_UNSIGNED_LONG 8
-#else
 #define SIZEOF_UNSIGNED_LONG 4
-#endif
 
 /* The size of `void *', as computed by sizeof. */
 #ifdef _WIN64
@@ -157,7 +159,9 @@ char *strerror(int errno);
 # include <fcntl.h>
 # include <io.h>
 # define isatty _isatty
-# define snprintf _snprintf
+# if _MSC_VER < 1900
+#  define snprintf _snprintf
+# endif
 #endif
 
 #endif /* GIFSICLE_CONFIG_H */


### PR DESCRIPTION
There was a [post on encode.ru](http://encode.ru/threads/2481-How-to-compile-giflossy) asking how to compile this on Windows, so I took a shot at updating the makefile and config for Visual C++ 2015.

gifsicle builds with 32- and 64-bit MSVC now, but I haven't tested it.